### PR TITLE
Backend code for rdbms datastore is public static constant now

### DIFF
--- a/common/src/main/java/com/redhat/lightblue/common/rdbms/RDBMSDataStore.java
+++ b/common/src/main/java/com/redhat/lightblue/common/rdbms/RDBMSDataStore.java
@@ -30,6 +30,8 @@ public class RDBMSDataStore implements DataStore, Serializable {
 
     private static final long serialVersionUID = 1l;
 
+    public static final String BACKEND = "rdbms";
+
     private String datasourceName;
     private String databaseName;
 
@@ -44,7 +46,7 @@ public class RDBMSDataStore implements DataStore, Serializable {
 
     @Override
     public String getBackend() {
-        return "rdbms";
+        return BACKEND;
     }
 
     public String getDatasourceName() {


### PR DESCRIPTION
Could be used later to update audit hook to support rdbms.  Right now audit hook will support just mongo.
