### PR TITLE
Fix travis deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 jdk:
     - openjdk7
     - oraclejdk8
+    - oraclejdk7
 before_install:
     - cp ./etc/settings.xml ~/.m2/
     - cp ./etc/onFailure.sh  ~/

--- a/etc/onSuccess.sh
+++ b/etc/onSuccess.sh
@@ -1,5 +1,9 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
-echo "DEPLOY MASTER TRAVIS BUILD"
-echo "Current directory is $(pwd)"
-'[[ $TRAVIS_BRANCH == "master" ]] && [[ $TRAVIS_JDK_VERSION == "openjdk7" ]] && { mvn clean deploy -DskipTests; };'
+echo "after_success script"
+
+if [ "$TRAVIS_BRANCH" == "master" ] && [ "$TRAVIS_JDK_VERSION" == "openjdk7" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ]; then
+    echo "DEPLOY MASTER TRAVIS BUILD"
+    echo "Current directory is $(pwd)"
+    mvn clean deploy -DskipTests;
+fi


### PR DESCRIPTION
The etc/onSuccess.sh scrippt had the previous statement on the .travis.yml . It doesn't seem to be working (not sure if it worked previously). The fix is just refactoring the shell script control flow so it can run the command to deploy (remote maven repository) when it is using openjdk7 and master branch if it isn't a PR